### PR TITLE
fix: exclude fee lines with zero value

### DIFF
--- a/csf_za/overrides/accounts/bank_statement_import.py
+++ b/csf_za/overrides/accounts/bank_statement_import.py
@@ -187,7 +187,15 @@ class CustomBankStatementImport(BankStatementImport):
 		file_content = file_doc.get_content()
 		data = read_csv_content(file_content)
 
-		expected_headers = ["Account", "Date", "Description", "Reference", "Amount", "Fees", "Balance"]
+		expected_headers = [
+			"Account",
+			"Date",
+			"Description",
+			"Reference",
+			"Amount",
+			"Fees",
+			"Balance",
+		]
 		if data[2][:7] != expected_headers:
 			frappe.throw(_("Unexpected headers in CSV. Expected: {0}").format(", ".join(expected_headers)))
 		if not data:
@@ -214,7 +222,8 @@ class CustomBankStatementImport(BankStatementImport):
 			new_data.append(new_row)
 
 			# Create a new row if this row has a fee
-			if row[5] != None:
+			print(f"\n\n{row[5]}\n\n")
+			if row[5] != None and float(row[5]) != 0:
 				try:
 					fee_value = float(row[5])
 				except ValueError:


### PR DESCRIPTION
## Description

In Bank Statement Import tool, excluded fee lines with a value of 0.

## Type of change

- ⚪ Bug fix (change which fixes an issue)


## Tests

- [x] [Unit Tests](https://frappeframework.com/docs/user/en/guides/automated-testing/unit-testing) have been updated or added, as required
- [x] [UI Tests](https://frappeframework.com/docs/user/en/ui-testing) have been updated or added, as required

## Checklist:

- [x] My code follows [Naming Guidelines](https://github.com/frappe/erpnext/wiki/Naming-Guidelines) (DocType, Field  and Variable naming)
- [x] No Form changes */* My code follows the [Form Design Guidelines](https://github.com/frappe/erpnext/wiki/Form-Design-Guidelines)
- [x] My code follows the [Coding Standards](https://github.com/frappe/erpnext/wiki/Coding-Standards) of this project
- [x] My code follows the [Code Security Guidelines](https://github.com/frappe/erpnext/wiki/Code-Security-Guidelines) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas */* No comments necessary
- [ ] I have made corresponding additions/changes to the documentation
- [x] All business logic and validations are on the server-side */* No business logic or validation changes
- [x] No patches are necessary */* Migration Patches have been added to the correct subdirectory of `/patches` and `patches.txt` have been updated


## User Experience:

Users will no longer import fee lines on Bank Statement imports where the fee value is 0.
